### PR TITLE
Add macOS support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.machineTag }}
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: leafo/gh-actions-lua@master
       with:
         luaVersion: ${{ matrix.luaVersion }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         luaVersion: ["5.1.5", "5.2.4", "5.3.5", "5.4.0", "luajit-2.0.5", "luajit-2.1.0-beta3", "luajit-openresty", "5.1", "5.4"]
+        machineTag: ["ubuntu-latest", "macos-latest"]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.machineTag }}
 
     steps:
     - uses: actions/checkout@master

--- a/main.js
+++ b/main.js
@@ -27,7 +27,8 @@ async function install_luajit_openresty() {
     cwd: installPath
   })
 
-  await exec.exec("make -j", undefined, {
+  const macOSDeploymentTarget = process.platform === 'darwin' ? ' MACOSX_DEPLOYMENT_TARGET=10.15' : ''
+  await exec.exec("make -j" + macOSDeploymentTarget, undefined, {
     cwd: path.join(installPath, "luajit2")
   })
 
@@ -51,7 +52,8 @@ async function install_luajit(luajitVersion) {
   await io.mkdirP(luaExtractPath)
   await tc.extractTar(luaSourceTar, INSTALL_PREFIX)
 
-  await exec.exec("make -j", undefined, {
+  const macOSDeploymentTarget = process.platform === 'darwin' ? ' MACOSX_DEPLOYMENT_TARGET=10.15' : ''
+  await exec.exec("make -j" + macOSDeploymentTarget, undefined, {
     cwd: luaExtractPath
   })
 
@@ -91,16 +93,21 @@ async function main() {
   await io.mkdirP(luaExtractPath)
   await tc.extractTar(luaSourceTar, INSTALL_PREFIX)
 
-  await exec.exec("sudo apt-get install -q libreadline-dev libncurses-dev", undefined, {
-    env: {
-      DEBIAN_FRONTEND: "noninteractive",
-      TERM: "linux"
-    }
-  })
+  if (process.platform === 'darwin') {
+    await exec.exec("brew install readline ncurses")
+  } else {
+    await exec.exec("sudo apt-get install -q libreadline-dev libncurses-dev", undefined, {
+      env: {
+        DEBIAN_FRONTEND: "noninteractive",
+        TERM: "linux"
+      }
+    })
+  }
 
+  const makefilePlatform = process.platform === "darwin" ? "macosx" : "linux"
   const compileFlagsArray = [
     "-j",
-    "linux",
+    makefilePlatform,
   ]
 
   if (luaCompileFlags) {


### PR DESCRIPTION
This now runs under macOS runners. Ideally, the deployment target shouldn't be hardcoded to 10.15, but it won't break when 11.0 releases.

Fixes #8 