### PR TITLE
Reference local checked-out copy of gh-actions-lua in workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
-    - uses: leafo/gh-actions-lua@master
+    - uses: actions/checkout@main
+    - uses: './'
       with:
         luaVersion: ${{ matrix.luaVersion }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@main
-    - uses: leafo/gh-actions-lua@master
+    - uses: './'
       with:
         luaVersion: ${{ matrix.luaVersion }}
 


### PR DESCRIPTION
Just found out you can do this and decided to make a PR here as well.