### PR TITLE
Windows support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[*.js]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         buildCache: false
 
     - name: Test Lua
-      run: lua -e 'print("hi from lua")'
+      run: lua -e "print('hi from lua')"
 
   test-cache:
     needs: test
@@ -46,4 +46,4 @@ jobs:
         luaVersion: ${{ matrix.luaVersion }}
 
     - name: Test Lua
-      run: lua -e 'print("hi from lua")'
+      run: lua -e "print('hi from lua')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         luaVersion: ["5.1.5", "5.2.4", "5.3.5", "5.4.1", "luajit-2.0.5", "luajit-2.1.0-beta3", "luajit-openresty", "5.1", "5.4"]
-        machineTag: ["ubuntu-latest", "macos-latest"]
+        machineTag: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
     runs-on: ${{ matrix.machineTag }}
 
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         luaVersion: ["5.1.5", "5.2.4", "5.3.5", "5.4.1", "luajit-2.0.5", "luajit-2.1.0-beta3", "luajit-openresty", "5.1", "5.4"]
-        machineTag: ["ubuntu-latest", "macos-latest"]
+        machineTag: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
     runs-on: ${{ matrix.machineTag }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@main
 
+    - uses: ilammy/msvc-dev-cmd@v1
+
     - name: Build Lua
       uses: './'
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        luaVersion: ["5.1.5", "5.2.4", "5.3.5", "5.4.1", "luajit-2.0.5", "luajit-2.1.0-beta3", "luajit-openresty", "5.1", "5.4"]
+        luaVersion: ["5.1.5", "5.2.4", "5.3.6", "5.4.4", "luajit-2.0.5", "luajit-2.1.0-beta3", "luajit-openresty", "5.1", "5.4"]
         machineTag: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
     runs-on: ${{ matrix.machineTag }}
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        luaVersion: ["5.1.5", "5.2.4", "5.3.5", "5.4.1", "luajit-2.0.5", "luajit-2.1.0-beta3", "luajit-openresty", "5.1", "5.4"]
+        luaVersion: ["5.1.5", "5.2.4", "5.3.6", "5.4.4", "luajit-2.0.5", "luajit-2.1.0-beta3", "luajit-openresty", "5.1", "5.4"]
         machineTag: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
     runs-on: ${{ matrix.machineTag }}

--- a/main.js
+++ b/main.js
@@ -24,6 +24,12 @@ const VERSION_ALIASES = {
 
 const isMacOS = () => (process.platform || "").startsWith("darwin")
 
+// Returns posix path for process.cwd()
+const processCwd = () => {
+  const p = require("path");
+  return process.cwd().split(p.sep).join(p.posix.sep);
+}
+
 async function install_luajit_openresty(luaInstallPath) {
   const buildPath = path.join(process.env["RUNNER_TEMP"], BUILD_PREFIX)
   const luaCompileFlags = core.getInput('luaCompileFlags')
@@ -146,7 +152,7 @@ async function main() {
     luaVersion = VERSION_ALIASES[luaVersion]
   }
 
-  const luaInstallPath = path.join(process.cwd(), LUA_PREFIX)
+  const luaInstallPath = path.join(processCwd(), LUA_PREFIX)
 
   let toolCacheDir = tc.find('lua', luaVersion)
 

--- a/main.js
+++ b/main.js
@@ -23,23 +23,28 @@ const VERSION_ALIASES = {
 }
 
 const isMacOS = () => (process.platform || "").startsWith("darwin")
+const isWindows = () => (process.platform || "").startsWith("win32")
+
+const exists = (filename, mode) => fsp.access(filename, mode).then(() => true, () => false)
+
+// Returns posix path for path.join()
+const pathJoin = path.posix.join
 
 // Returns posix path for process.cwd()
 const processCwd = () => {
-  const p = require("path");
-  return process.cwd().split(p.sep).join(p.posix.sep);
+  return process.cwd().split(path.sep).join(path.posix.sep);
 }
 
 async function finish_luajit_install(src, dst, luajit) {
   if (isWindows()) {
-    await fsp.copyFile(path.join(src, "lua51.dll"), path.join(dst, "bin", "lua51.dll"))
+    await fsp.copyFile(pathJoin(src, "lua51.dll"), pathJoin(dst, "bin", "lua51.dll"))
 
     await exec.exec(`ln -s ${luajit} lua.exe`, undefined, {
-      cwd: path.join(dst, "bin")
+      cwd: pathJoin(dst, "bin")
     })
   } else {
     await exec.exec(`ln -s ${luajit} lua`, undefined, {
-      cwd: path.join(dst, "bin")
+      cwd: pathJoin(dst, "bin")
     })
   }
 }
@@ -65,18 +70,18 @@ async function install_luajit_openresty(luaInstallPath) {
   }
 
   await exec.exec(`make ${finalCompileFlags}`, undefined, {
-    cwd: path.join(buildPath, "luajit2")
+    cwd: pathJoin(buildPath, "luajit2")
   })
 
   await exec.exec(`make -j install PREFIX="${luaInstallPath}"`, undefined, {
-    cwd: path.join(buildPath, "luajit2")
+    cwd: pathJoin(buildPath, "luajit2")
   })
 
-  await finish_luajit_install(path.join(installPath, "luajit2", "src"), luaInstallPath, "luajit-2.1.0-beta3")
+  await finish_luajit_install(pathJoin(buildPath, "luajit2", "src"), luaInstallPath, "luajit-2.1.0-beta3")
 }
 
 async function install_luajit(luaInstallPath, luajitVersion) {
-  const luaExtractPath = path.join(process.env["RUNNER_TEMP"], BUILD_PREFIX, `LuaJIT-${luajitVersion}`)
+  const luaExtractPath = pathJoin(process.env["RUNNER_TEMP"], BUILD_PREFIX, `LuaJIT-${luajitVersion}`)
 
   const luaCompileFlags = core.getInput('luaCompileFlags')
 
@@ -102,16 +107,101 @@ async function install_luajit(luaInstallPath, luajitVersion) {
     cwd: luaExtractPath
   })
 
-  await finish_luajit_install(path.join(luaExtractPath, "src"), luaInstallPath, `luajit-${luajitVersion}`)
+  await finish_luajit_install(pathJoin(luaExtractPath, "src"), luaInstallPath, `luajit-${luajitVersion}`)
+}
+
+async function msvc_link(luaExtractPath, linkCmd, outFile, objs) {
+  await exec.exec(linkCmd + " /out:" + outFile, objs, {
+    cwd: luaExtractPath
+  })
+
+  let manifest = outFile + ".manifest"
+  if (await exists(manifest)) {
+    await exec.exec("mt /nologo", ["-manifest", manifest, "-outputresource:" + outFile], {
+      cwd: luaExtractPath
+    })
+  }
+}
+
+async function install_files(dstDir, srcDir, files) {
+  await io.mkdirP(dstDir)
+  for (let file of files) {
+    await fsp.copyFile(pathJoin(srcDir, file), pathJoin(dstDir, path.posix.basename(file)))
+  }
+}
+
+async function install_plain_lua_windows(luaExtractPath, luaInstallPath, luaVersion) {
+  const luaCompileFlags = core.getInput('luaCompileFlags')
+
+  let cl = "cl /nologo /MD /O2 /W3 /c /D_CRT_SECURE_NO_DEPRECATE"
+
+  let objs = {
+    "lib": [],
+    "lua": [],
+    "luac": [],
+  }
+
+  let sources = {
+    "lua": [ "lua.c" ],
+    "luac": [ "luac.c", "print.c" ],
+  }
+
+  let src = pathJoin(luaExtractPath, "src")
+
+  await fsp.readdir(src).then(async (files) => {
+    for (let file of files) {
+      if (file.endsWith(".c")) {
+        let mode = sources["lua"].includes(file)
+                 ? "lua"
+                 : sources["luac"].includes(file)
+                 ? "luac"
+                 : "lib"
+
+        let srcName = pathJoin("src", file)
+
+        let args = (mode === "lib")
+                 ? [ "-DLUA_BUILD_AS_DLL", srcName ]
+                 : [ srcName ]
+
+        objs[mode].push(file.replace(".c", ".obj"))
+
+        await exec.exec(cl, args, {
+          cwd: luaExtractPath
+        })
+      }
+    }
+  })
+
+  objs["lua"] = [ ...objs["lua"], ...objs["lib"] ]
+  objs["luac"] = [ ...objs["luac"], ...objs["lib"] ]
+
+  let luaXYZ = luaVersion.split(".")
+  let libFile = "lua" + luaXYZ[0] + luaXYZ[1] + ".lib"
+  let dllFile = "lua" + luaXYZ[0] + luaXYZ[1] + ".dll"
+
+  await msvc_link(luaExtractPath, "link /nologo /DLL", dllFile, objs["lib"]);
+  await msvc_link(luaExtractPath, "link /nologo", "luac.exe", objs["luac"]);
+  await msvc_link(luaExtractPath, "link /nologo", "lua.exe", objs["lua"]);
+
+  const luaHpp = (await exists(pathJoin(src, "lua.hpp"))) ? "lua.hpp" : "../etc/lua.hpp"
+  const headers = [ "lua.h", "luaconf.h", "lualib.h", "lauxlib.h", luaHpp ]
+
+  await install_files(pathJoin(luaInstallPath, "bin"), luaExtractPath, [ "lua.exe", "luac.exe" ])
+  await install_files(pathJoin(luaInstallPath, "lib"), luaExtractPath, [ dllFile, libFile ])
+  await install_files(pathJoin(luaInstallPath, "include"), src, headers)
 }
 
 async function install_plain_lua(luaInstallPath, luaVersion) {
-  const luaExtractPath = path.join(process.env["RUNNER_TEMP"], BUILD_PREFIX, `lua-${luaVersion}`)
+  const luaExtractPath = pathJoin(process.env["RUNNER_TEMP"], BUILD_PREFIX, `lua-${luaVersion}`)
   const luaCompileFlags = core.getInput('luaCompileFlags')
 
   const luaSourceTar = await tc.downloadTool(`https://www.lua.org/ftp/lua-${luaVersion}.tar.gz`)
   await io.mkdirP(luaExtractPath)
   await tc.extractTar(luaSourceTar, path.join(process.env["RUNNER_TEMP"], BUILD_PREFIX))
+
+  if (isWindows()) {
+    return await install_plain_lua_windows(luaExtractPath, luaInstallPath, luaVersion);
+  }
 
   if (isMacOS()) {
     await exec.exec("brew install readline ncurses")
@@ -153,7 +243,6 @@ async function install(luaInstallPath, luaVersion) {
 }
 
 const makeCacheKey = (luaVersion, compileFlags) => `lua:${luaVersion}:${process.platform}:${process.arch}:${compileFlags}`
-const exists = (filename, mode) => fsp.access(filename, mode).then(() => true, () => false)
 
 async function main() {
   let luaVersion = core.getInput('luaVersion', { required: true })
@@ -162,7 +251,7 @@ async function main() {
     luaVersion = VERSION_ALIASES[luaVersion]
   }
 
-  const luaInstallPath = path.join(processCwd(), LUA_PREFIX)
+  const luaInstallPath = pathJoin(processCwd(), LUA_PREFIX)
 
   let toolCacheDir = tc.find('lua', luaVersion)
 
@@ -195,7 +284,7 @@ async function main() {
     await fsp.symlink(toolCacheDir, luaInstallPath);
   }
 
-  core.addPath(path.join(luaInstallPath, "bin"))
+  core.addPath(pathJoin(luaInstallPath, "bin"))
 }
 
 main().catch(err => {

--- a/main.js
+++ b/main.js
@@ -30,6 +30,20 @@ const processCwd = () => {
   return process.cwd().split(p.sep).join(p.posix.sep);
 }
 
+async function finish_luajit_install(src, dst, luajit) {
+  if (isWindows()) {
+    await fsp.copyFile(path.join(src, "lua51.dll"), path.join(dst, "bin", "lua51.dll"))
+
+    await exec.exec(`ln -s ${luajit} lua.exe`, undefined, {
+      cwd: path.join(dst, "bin")
+    })
+  } else {
+    await exec.exec(`ln -s ${luajit} lua`, undefined, {
+      cwd: path.join(dst, "bin")
+    })
+  }
+}
+
 async function install_luajit_openresty(luaInstallPath) {
   const buildPath = path.join(process.env["RUNNER_TEMP"], BUILD_PREFIX)
   const luaCompileFlags = core.getInput('luaCompileFlags')
@@ -58,9 +72,7 @@ async function install_luajit_openresty(luaInstallPath) {
     cwd: path.join(buildPath, "luajit2")
   })
 
-  await exec.exec("ln -s luajit lua", undefined, {
-    cwd: path.join(luaInstallPath, "bin")
-  })
+  await finish_luajit_install(path.join(installPath, "luajit2", "src"), luaInstallPath, "luajit-2.1.0-beta3")
 }
 
 async function install_luajit(luaInstallPath, luajitVersion) {
@@ -90,9 +102,7 @@ async function install_luajit(luaInstallPath, luajitVersion) {
     cwd: luaExtractPath
   })
 
-  await exec.exec(`ln -s luajit-${luajitVersion} lua`, undefined, {
-    cwd: path.join(luaInstallPath, "bin")
-  })
+  await finish_luajit_install(path.join(luaExtractPath, "src"), luaInstallPath, `luajit-${luajitVersion}`)
 }
 
 async function install_plain_lua(luaInstallPath, luaVersion) {


### PR DESCRIPTION
This expands on the work by @chipsenkbeil by adding support for PUC-Rio Lua on Windows, by launching the compiler ourselves, since the provided Makefile is pretty much Unix-only. The logic here is based on similar Python code [implemented by hererocks](https://github.com/luarocks/hererocks/blob/e44d384288c5385cdcfda92e662756fcd2d9eb8a/hererocks.py).

The PUC-Rio Lua build is done using MSVC, while the LuaJIT build by @chipsenkbeil uses Mingw. I haven't tried building using the upstream Lua compiler with Mingw — I've personally only used it for cross-compiling from a Unix host, not sure how well that works from Windows, and I thought it would be useful to provide a MSVC-based option. To use MSVC, one needs to enable the compiler that's included in Actions's `windows-latest` container. Hererocks jumps through several hoops to do that, but here it was a matter of loading another Action, [illamy/msvc-dev-cmd](https://github.com/ilammy/msvc-dev-cmd).

Additional commits:
* make sure that `lua51.dll` is installed in the `bin` dir when deploying LuaJIT (the visible difference is that the "Test Lua" step now correctly displays `hi from lua` on all jobs; LuaJIT did compile on #19 and that job passed, but the output didn't show before).
* bump Lua 5.4 to 5.4.4
* .editorconfig file for convenience

Closes #19.
Closes #6.