### PR TITLE
Fix C module loading on windows

### DIFF
--- a/main.js
+++ b/main.js
@@ -172,12 +172,12 @@ async function install_plain_lua_windows(luaExtractPath, luaInstallPath, luaVers
     }
   })
 
-  objs["lua"] = [ ...objs["lua"], ...objs["lib"] ]
-  objs["luac"] = [ ...objs["luac"], ...objs["lib"] ]
-
   let luaXYZ = luaVersion.split(".")
   let libFile = "lua" + luaXYZ[0] + luaXYZ[1] + ".lib"
   let dllFile = "lua" + luaXYZ[0] + luaXYZ[1] + ".dll"
+
+  objs["lua"] = [ ...objs["lua"], libFile ]
+  objs["luac"] = [ ...objs["luac"], ...objs["lib"] ]
 
   await msvc_link(luaExtractPath, "link /nologo /DLL", dllFile, objs["lib"]);
   await msvc_link(luaExtractPath, "link /nologo", "luac.exe", objs["luac"]);
@@ -186,7 +186,7 @@ async function install_plain_lua_windows(luaExtractPath, luaInstallPath, luaVers
   const luaHpp = (await exists(pathJoin(src, "lua.hpp"))) ? "lua.hpp" : "../etc/lua.hpp"
   const headers = [ "lua.h", "luaconf.h", "lualib.h", "lauxlib.h", luaHpp ]
 
-  await install_files(pathJoin(luaInstallPath, "bin"), luaExtractPath, [ "lua.exe", "luac.exe" ])
+  await install_files(pathJoin(luaInstallPath, "bin"), luaExtractPath, [ "lua.exe", "luac.exe", dllFile ])
   await install_files(pathJoin(luaInstallPath, "lib"), luaExtractPath, [ dllFile, libFile ])
   await install_files(pathJoin(luaInstallPath, "include"), src, headers)
 }


### PR DESCRIPTION
This PR addresses #39 and introduces 2 changes to the windows plain lua build:
- Installs `luaxx.dll` next to `lua.exe` (`bin/`) where it can be picked up at runtime by native libraries linked against it
- Links `lua.exe` against `luaxx.dll` to avoid "multiple lua VMs" errors