### PR TITLE
fix: change www.lua.org to lua.org to reflect certificate change

### DIFF
--- a/main.js
+++ b/main.js
@@ -195,7 +195,7 @@ async function install_plain_lua(luaInstallPath, luaVersion) {
   const luaExtractPath = pathJoin(process.env["RUNNER_TEMP"], BUILD_PREFIX, `lua-${luaVersion}`)
   const luaCompileFlags = core.getInput('luaCompileFlags')
 
-  const luaSourceTar = await tc.downloadTool(`https://www.lua.org/ftp/lua-${luaVersion}.tar.gz`)
+  const luaSourceTar = await tc.downloadTool(`https://lua.org/ftp/lua-${luaVersion}.tar.gz`)
   await io.mkdirP(luaExtractPath)
   await tc.extractTar(luaSourceTar, path.join(process.env["RUNNER_TEMP"], BUILD_PREFIX))
 


### PR DESCRIPTION
Looks like https://lua.org/ 's certificate changed today.

```text
* Server certificate:                                                                                                                                                       *  subject: CN=lua.org                                                                                                                                                      *  start date: Dec 20 17:54:42 2023 GMT
*  expire date: Mar 19 17:54:41 2024 GMT
*  subjectAltName: host "lua.org" matched cert's "lua.org"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
```

```text
Run leafo/gh-actions-lua@v10
  with:
    luaVersion: 5.4
    buildCache: true
Notice: gh-actions-lua: No cache available, clean build
Hostname/IP does not match certificate's altnames: Host: www.lua.org. is not in the cert's altnames: DNS:lua.org
Waiting 18 seconds before trying again
Hostname/IP does not match certificate's altnames: Host: www.lua.org. is not in the cert's altnames: DNS:lua.org
Waiting 1[6](https://github.com/vpayno/exercism-workspace/actions/runs/7284425228/job/19849762432?pr=323#step:3:7) seconds before trying again
Error: Failed to install
```