### PR TITLE
Update Node to version 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ inputs:
     default: 'true'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'


### PR DESCRIPTION
Github Action is transitioning away from Node 16 as it's End of Life.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/