### PR TITLE
Implement Mirror Support for Planned lua.org Outages #47

### DIFF
--- a/main.js
+++ b/main.js
@@ -196,7 +196,16 @@ async function install_plain_lua(luaInstallPath, luaVersion) {
   const luaExtractPath = pathJoin(process.env["RUNNER_TEMP"], BUILD_PREFIX, `lua-${luaVersion}`)
   const luaCompileFlags = core.getInput('luaCompileFlags')
 
-  const luaSourceTar = await tc.downloadTool(`https://lua.org/ftp/lua-${luaVersion}.tar.gz`)
+  const primaryUrl = `https://lua.org/ftp/lua-${luaVersion}.tar.gz`
+  const mirrorUrl = `https://www.tecgraf.puc-rio.br/lua/mirror/ftp/lua-${luaVersion}.tar.gz`
+  let luaSourceTar
+
+  try {
+    luaSourceTar = await tc.downloadTool(primaryUrl)
+  } catch (error) {
+    console.log('Primary URL is down, trying mirror URL...')
+    luaSourceTar = await tc.downloadTool(mirrorUrl)
+  }
   await io.mkdirP(luaExtractPath)
   await tc.extractTar(luaSourceTar, path.join(process.env["RUNNER_TEMP"], BUILD_PREFIX))
 

--- a/main.js
+++ b/main.js
@@ -200,12 +200,12 @@ async function install_plain_lua(luaInstallPath, luaVersion) {
   const mirrorUrl = `https://www.tecgraf.puc-rio.br/lua/mirror/ftp/lua-${luaVersion}.tar.gz`
   let luaSourceTar
 
-  try {
-    luaSourceTar = await tc.downloadTool(primaryUrl)
-  } catch (error) {
-    console.log('Primary URL is down, trying mirror URL...')
-    luaSourceTar = await tc.downloadTool(mirrorUrl)
-  }
+  const primaryDownload = tc.downloadTool(primaryUrl)
+  const mirrorDownload = tc.downloadTool(mirrorUrl)
+
+  luaSourceTar = await Promise.race([primaryDownload, mirrorDownload]).catch(async (error) => {
+    throw new Error(`Failed to download Lua source: ${error}`)
+  })
   await io.mkdirP(luaExtractPath)
   await tc.extractTar(luaSourceTar, path.join(process.env["RUNNER_TEMP"], BUILD_PREFIX))
 


### PR DESCRIPTION
This pull request aims to address the issue #47, where the action fails due to planned outages at lua.org. 

A mirror is available at https://www.tecgraf.puc-rio.br/lua/mirror/ and this PR modifies the main.js file to take this mirror into account during the outage periods.

Changes Made:
1. Updated the URL in main.js to switch to the mirror URL when lua.org is down.

Please review the changes and let me know if any modifications are required.